### PR TITLE
Fix time conflict bugs

### DIFF
--- a/src/main/java/seedu/waddle/commons/core/Messages.java
+++ b/src/main/java/seedu/waddle/commons/core/Messages.java
@@ -17,8 +17,8 @@ public class Messages {
     public static final String MESSAGE_CONFLICTING_ITEMS = "Quack, there is a time clash!"
             + "\nThe provided time clashes with:\n%1$sPlease change the start time and/or the duration.";
     public static final String MESSAGE_ITEM_PAST_MIDNIGHT =
-            "%1$s extends past midnight which is not currently supported.\n" +
-                    "Please split %1$s into 2 parts and plan the second part at the start of the next day.";
+            "%1$s extends past midnight which is not currently supported.\n"
+                    + "Please split %1$s into 2 parts and plan the second part at the start of the next day.";
     // not meant for users to see
     public static final String MESSAGE_UNKNOWN_STAGE = "Unknown stage, something went wrong with the StateManager.";
 }

--- a/src/main/java/seedu/waddle/commons/core/Messages.java
+++ b/src/main/java/seedu/waddle/commons/core/Messages.java
@@ -5,17 +5,20 @@ package seedu.waddle.commons.core;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_COPY_ERROR = "Unable to copy to clipboard";
-    public static final String MESSAGE_UNAVAILABLE_COMMAND_HOME = "Command is unavailable in the home page";
-    public static final String MESSAGE_UNAVAILABLE_COMMAND_ITINERARY = "Command is unavailable in the itinerary page";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command.";
+    public static final String MESSAGE_COPY_ERROR = "Unable to copy to clipboard.";
+    public static final String MESSAGE_UNAVAILABLE_COMMAND_HOME = "Command is unavailable in the home page.";
+    public static final String MESSAGE_UNAVAILABLE_COMMAND_ITINERARY = "Command is unavailable in the itinerary page.";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_ITINERARY_DISPLAYED_INDEX = "The itinerary index provided is invalid";
-    public static final String MESSAGE_INVALID_ITEM_DISPLAYED_INDEX = "The item index provided is invalid";
+    public static final String MESSAGE_INVALID_ITINERARY_DISPLAYED_INDEX = "The itinerary index provided is invalid.";
+    public static final String MESSAGE_INVALID_ITEM_DISPLAYED_INDEX = "The item index provided is invalid.";
     public static final String MESSAGE_ITINERARIES_LISTED_OVERVIEW = "%1$d itineraries listed!";
     public static final String MESSAGE_INVALID_STAGE = "The stage you provided is invalid! \n%1$s";
     public static final String MESSAGE_CONFLICTING_ITEMS = "Quack, there is a time clash!"
             + "\nThe provided time clashes with:\n%1$sPlease change the start time and/or the duration.";
+    public static final String MESSAGE_ITEM_PAST_MIDNIGHT =
+            "%1$s extends past midnight which is not currently supported.\n" +
+                    "Please split %1$s into 2 parts and plan the second part at the start of the next day.";
     // not meant for users to see
     public static final String MESSAGE_UNKNOWN_STAGE = "Unknown stage, something went wrong with the StateManager.";
 }

--- a/src/main/java/seedu/waddle/model/item/Item.java
+++ b/src/main/java/seedu/waddle/model/item/Item.java
@@ -72,18 +72,21 @@ public class Item {
     }
 
     public LocalTime getEndTime() {
-        LocalTime end = this.startTime.plusMinutes(this.duration.getDuration());
-        // if the time overflows to next day (including 00:00), set to 23:59
-        if (end.isBefore(this.startTime) || end.equals(LocalTime.MIDNIGHT)) {
-            return LocalTime.parse("23:59");
+        LocalTime endTime = this.startTime.plusMinutes(this.duration.getDuration());
+        if (this.startTime.isBefore(LocalTime.MAX) && endTime.equals(LocalTime.MIDNIGHT)) {
+            return LocalTime.MAX;
         }
-        return end;
+        return endTime;
     }
 
     public String getTimeString(int indents) {
         if (this.startTime != null) {
+            String endTime = getEndTime().toString();
+            if (getEndTime().equals(LocalTime.MAX)) {
+                endTime = LocalTime.MIDNIGHT.toString();
+            }
             if (this.duration != null) {
-                return Text.indent("Time: " + this.startTime + " - " + getEndTime(), indents);
+                return Text.indent("Time: " + this.startTime + " - " + endTime, indents);
             } else {
                 return Text.indent("Time: " + this.startTime, indents);
             }

--- a/src/main/java/seedu/waddle/model/item/exceptions/Period.java
+++ b/src/main/java/seedu/waddle/model/item/exceptions/Period.java
@@ -1,20 +1,19 @@
 package seedu.waddle.model.item.exceptions;
 
-import java.time.LocalDate;
 import java.time.LocalTime;
 
 /**
  * This class encapsulates a time period.
  */
 public class Period {
-    private LocalTime start;
-    private LocalTime end;
+    private final LocalTime start;
+    private final LocalTime end;
 
     /**
      * Constructor.
      *
      * @param start Start time.
-     * @param end End time.
+     * @param end   End time.
      */
     public Period(LocalTime start, LocalTime end) {
         //assert(end.isAfter(start) || start.equals(end)) : "start and end time must be valid";

--- a/src/main/java/seedu/waddle/model/item/exceptions/Period.java
+++ b/src/main/java/seedu/waddle/model/item/exceptions/Period.java
@@ -1,5 +1,6 @@
 package seedu.waddle.model.item.exceptions;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 /**
@@ -27,5 +28,16 @@ public class Period {
 
     public LocalTime getEnd() {
         return this.end;
+    }
+
+    public String getStartString() {
+        return this.start.toString();
+    }
+
+    public String getEndString() {
+        if (this.end.equals(LocalTime.MAX)) {
+            return LocalTime.MIDNIGHT.toString() + " (next day)";
+        }
+        return this.end.toString();
     }
 }

--- a/src/main/java/seedu/waddle/model/itinerary/Itinerary.java
+++ b/src/main/java/seedu/waddle/model/itinerary/Itinerary.java
@@ -196,7 +196,14 @@ public class Itinerary {
         Item item = this.unscheduledItemList.get(itemIndex.getZeroBased());
         item.setStartTime(startTime);
         Day day = this.days.get(dayNumber.dayNumber.getZeroBased());
-        day.addItem(item);
+        try {
+            day.addItem(item);
+        } catch (CommandException e) {
+            // if time conflict detected, reset the time of the item
+            item.resetStartTime();
+            throw e;
+        }
+
         this.unscheduledItemList.remove(itemIndex.getZeroBased());
         this.budget.updateSpending(item.getCost().getValue());
         return item;


### PR DESCRIPTION
Prevent user from planning item that overflows past midnight Added item past midnight error message.
Start time will now reset if there is a time conflict when planning. Free now works properly with midnight reflected as 00:00 (next day). Period and Item has time getString methods since midnight of the previous day is LocalTime.Max but shown as 00:00 as a string.

closes #123
closes #125